### PR TITLE
Using length args in serialization functions

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -1016,7 +1016,7 @@ static int json_serialize_to_buffer_r(_Ptr<const JSON_Value> value, char* buf : 
                 APPEND_STRING("\n");
             }
             for (i = 0; i < count; i++) {
-                key = (_Nt_array_ptr<const char>)json_object_get_name(object, i);
+                key = json_object_get_name(object, i);
                 if (key == NULL) {
                     return -1;
                 }
@@ -1574,7 +1574,7 @@ JSON_Value * json_value_deep_copy(const JSON_Value *value : itype(_Ptr<const JSO
             }
             temp_object_copy = json_value_get_object(return_value);
             for (i = 0; i < json_object_get_count(temp_object); i++) {
-                temp_key = (_Nt_array_ptr<const char>)json_object_get_name(temp_object, i);
+                temp_key = json_object_get_name(temp_object, i);
                 temp_value = json_object_get_value(temp_object, temp_key);
                 temp_value_copy = json_value_deep_copy(temp_value);
                 if (temp_value_copy == NULL) {

--- a/parson.c
+++ b/parson.c
@@ -78,7 +78,7 @@ static JSON_Free_Function parson_free;
 #define parson_free_unchecked(buf) (free(buf))
 
 static _Nt_array_ptr<char> parson_string_malloc(size_t sz) : count(sz) _Unchecked {
-  if(sz >= SIZE_MAX) 
+  if(sz >= SIZE_MAX)
     return NULL;
   char *p = (char*)parson_malloc(char, sz + 1);
   if (p != NULL)
@@ -457,8 +457,8 @@ static JSON_Status json_object_resize(_Ptr<JSON_Object> object, size_t new_capac
         /* TODO: Memcpy functions below warn "cannot prove argument meets declared 
         * bounds" 1st arg truly won't prove unless new_capacity > object->count, 
         * which isn't checked here! It isn't exactly determined in the caller either.
-        * This sort of means we can't prove the second arg either, since we 
-        * can't really know that count <= capacity. (Even if we could, 
+        * This sort of means we can't prove the second arg either, since we
+        * can't really know that count <= capacity. (Even if we could,
         * the compiler would have trouble with "<")
         *  This reasoning applies to both memcpy functions below. */
         if (object->names != NULL && object->values != NULL && object->count > 0) {
@@ -586,7 +586,7 @@ static JSON_Status json_array_resize(_Ptr<JSON_Array> array, size_t new_capacity
     // TODO: The compiler can't do a >= comparison, so unneeded dynamic bounds cast.
     if (array->items != NULL && array->count > 0) {
         memcpy<_Ptr<JSON_Value>>(_Dynamic_bounds_cast<_Array_ptr<_Ptr<JSON_Value>>>(new_items, byte_count(array->count * sizeof(_Ptr<JSON_Value>))), 
-               _Dynamic_bounds_cast<_Array_ptr<_Ptr<JSON_Value>>>(array->items, byte_count(array->count * sizeof(_Ptr<JSON_Value>))), 
+               _Dynamic_bounds_cast<_Array_ptr<_Ptr<JSON_Value>>>(array->items, byte_count(array->count * sizeof(_Ptr<JSON_Value>))),
                array->count * sizeof(_Ptr<JSON_Value>));
     }
     parson_free(_Ptr<JSON_Value>, array->items);
@@ -1101,9 +1101,9 @@ static int json_serialize_to_buffer_r(_Ptr<const JSON_Value> value, _Nt_array_pt
     }
 }
 
-static int json_serialize_string(_Nt_array_ptr<const char> str_unbounded, 
-                                 _Nt_array_ptr<char> buf : bounds(buf_start, buf_start + buf_len), 
-                                 _Nt_array_ptr<char> buf_start : byte_count(buf_len), 
+static int json_serialize_string(_Nt_array_ptr<const char> str_unbounded,
+                                 _Nt_array_ptr<char> buf : bounds(buf_start, buf_start + buf_len),
+                                 _Nt_array_ptr<char> buf_start : byte_count(buf_len),
                                  size_t buf_len) {
     size_t i = 0, len = strlen(str_unbounded);
     _Nt_array_ptr<const char> string : count(len) = NULL;
@@ -1178,8 +1178,8 @@ static int json_serialize_string(_Nt_array_ptr<const char> str_unbounded,
 }
 
 static int append_indent(_Nt_array_ptr<char> buf : bounds(buf_start, buf_start + buf_len),
-                         int level, 
-                         _Nt_array_ptr<char> buf_start : byte_count(buf_len), 
+                         int level,
+                         _Nt_array_ptr<char> buf_start : byte_count(buf_len),
                          size_t buf_len) {
     int i;
     int written = -1, written_total = 0;
@@ -1204,8 +1204,8 @@ static int append_string(_Nt_array_ptr<char> buf : bounds(buf_start, buf_start +
         boundedString = _Assume_bounds_cast<_Array_ptr<char>>(string, count(len));
     }
     _Dynamic_check(buf >= buf_start && buf + len < buf_start + buf_len);
-    memcpy<char>(_Dynamic_bounds_cast<_Nt_array_ptr<char>>(buf, count(len)), 
-                 boundedString, 
+    memcpy<char>(_Dynamic_bounds_cast<_Nt_array_ptr<char>>(buf, count(len)),
+                 boundedString,
                  len);
     buf[len] = '\0';
     return len;
@@ -1245,7 +1245,6 @@ JSON_Value * json_parse_string(const char *string : itype(_Nt_array_ptr<const ch
         if (tmp[0] == '\xEF' && tmp[1] == '\xBB' && tmp[2] == '\xBF') {
             string = string + 3; /* Support for UTF-8 BOM */
         }
-    
         return parse_value((_Ptr<_Nt_array_ptr<const char>>)&string, 0);
     }
 }

--- a/parson.c
+++ b/parson.c
@@ -376,7 +376,7 @@ static void remove_comments(char* string : itype(_Nt_array_ptr<char>), _Nt_array
                         for (i = 0; i < (ptr - string) + end_token_len; i++) {
                             string[i] = ' ';
                         }
-                        // TODO: Don't understand the compiler warning here. Yes string bounds have changed to ptr, ptr + 0, what is the complaint?
+                        
                         string = _Assume_bounds_cast<_Nt_array_ptr<char>>(ptr + end_token_len - 1, count(0));
                     }
                 }

--- a/parson.c
+++ b/parson.c
@@ -1709,7 +1709,6 @@ JSON_Status json_serialize_to_buffer_pretty(const JSON_Value *value : itype(_Ptr
         buf[0] = '\0';
         return JSONFailure;
     }
-    
     buf[written] = '\0';
     return JSONSuccess;
 }

--- a/parson.h
+++ b/parson.h
@@ -90,13 +90,13 @@ JSON_Value * json_parse_string_with_comments(const char *string : itype(_Nt_arra
 
 /* Serialization */
 size_t      json_serialization_size(const JSON_Value *value : itype(_Ptr<const JSON_Value>)); /* returns 0 on fail */
-JSON_Status json_serialize_to_buffer(const JSON_Value *value : itype(_Ptr<const JSON_Value>), char *buf : itype(_Array_ptr<char>) byte_count(buf_size_in_bytes), size_t buf_size_in_bytes);
+JSON_Status json_serialize_to_buffer(const JSON_Value *value : itype(_Ptr<const JSON_Value>), char *buf : itype(_Nt_array_ptr<char>) byte_count(buf_size_in_bytes), size_t buf_size_in_bytes);
 JSON_Status json_serialize_to_file(const JSON_Value *value : itype(_Ptr<const JSON_Value>), const char *filename : itype(_Nt_array_ptr<const char>));
 char *      json_serialize_to_string(const JSON_Value *value : itype(_Ptr<const JSON_Value>)) : itype(_Nt_array_ptr<char>);
 
 /* Pretty serialization */
 size_t      json_serialization_size_pretty(const JSON_Value *value : itype(_Ptr<const JSON_Value>)); /* returns 0 on fail */
-JSON_Status json_serialize_to_buffer_pretty(const JSON_Value *value : itype(_Ptr<const JSON_Value>), char *buf : itype(_Array_ptr<char>) byte_count(buf_size_in_bytes), size_t buf_size_in_bytes);
+JSON_Status json_serialize_to_buffer_pretty(const JSON_Value *value : itype(_Ptr<const JSON_Value>), char *buf : itype(_Nt_array_ptr<char>) byte_count(buf_size_in_bytes), size_t buf_size_in_bytes);
 JSON_Status json_serialize_to_file_pretty(const JSON_Value *value : itype(_Ptr<const JSON_Value>), const char *filename : itype(_Nt_array_ptr<const char>));
 char *      json_serialize_to_string_pretty(const JSON_Value *value : itype(_Ptr<const JSON_Value>)) : itype(_Nt_array_ptr<char>);
 


### PR DESCRIPTION
Per the PR comments on #7 , here's a branch that adds length arguments to the serialization functions, based off the model currently in master but with slightly cleaner syntax from this round of translation. I've set up this PR to compare to the code you were commenting on previously because that seems the most useful, but *I don't actually want to merge these*. I think what I want to do is have this branch become `master`, with the older kludgier translation relegated to some branch. (Another useful comparison for reviewing this code might be https://github.com/microsoft/checkedc-parson/compare/newBaseline...withLengthArgs?expand=1 which is the original parson code that this translation was based off of.)
I believe that this branch addresses all comments from PR #7 (which can just be deleted after this branch replaces `master`), but I think it is useful to have `checkedCTranslation` as a separate branch from this one to see how to fix some of the issues surfaced by CheckedC! We might want to add some documentation somewhere about this.