### PR TITLE
Add the header inclusion needed for SIZE_MAX to be defined

### DIFF
--- a/parson.c
+++ b/parson.c
@@ -33,6 +33,7 @@
 #pragma CHECKED_SCOPE off
 
 #include <ctype.h> /* On Windows this needs a bounds safe interface or to be outside checked scope */
+#include <stdint.h> /* Needed for SIZE_MAX */
 
 #pragma CHECKED_SCOPE on
 


### PR DESCRIPTION
Current code produces a compilation problem on Mac/Linux systems because `SIZE_MAX` is defined in the header `stdint.h` which is missing. I believe that the `version1-summer-2018` branch also has this issue.